### PR TITLE
Test refactor

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -7,7 +7,7 @@ class Queue {
   }
 
   offer(...values) {
-    if (values.includes(null)) {
+    if (values.includes(undefined) || values.includes(null)) {
       throw new Error('Null values are not allowed')
     }
     this.contents = this.contents.concat(values)
@@ -15,7 +15,7 @@ class Queue {
 
   poll() {
     if (this.isEmpty) {
-      return null
+      return undefined
     }
     // TODO: O(n) performance, replace array with a FIFO-queue
     return this.contents.shift()
@@ -23,7 +23,7 @@ class Queue {
 
   peek() {
     if (this.isEmpty) {
-      return null
+      return undefined
     }
     return this.contents[0]
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limeeng/semaphore",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Semaphores, with promises. Limit access to resources in a safe and easy manner",
   "main": "index.js",
   "repository": {

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -1,142 +1,155 @@
 'use strict'
 
 const assert = require('assert').strict
+const testing = require('./test-utility.js')
 const Queue = require('../lib/queue.js')
 
 describe('Queue', function () {
   describe('constructor', function () {
     it('should be empty when instantiated', function () {
       const queue = new Queue()
-      assert.deepEqual(0, queue.size)
-      assert.deepEqual(true, queue.isEmpty)
+      assert.deepStrictEqual(queue.size, 0)
+      assert.deepStrictEqual(queue.isEmpty, true)
     })
   })
+
   describe('.offer(...values)', function () {
     it('should update size and isEmpty', function () {
       const queue = new Queue()
       queue.offer(1, 2, 3, 4, 5)
-      assert.deepEqual(5, queue.size)
-      assert.deepEqual(false, queue.isEmpty)
+      assert.deepStrictEqual(queue.size, 5)
+      assert.deepStrictEqual(queue.isEmpty, false)
     })
+
     it('should not break down arrays', function () {
       const queue = new Queue()
       const data = [1, 2, 3]
       queue.offer(data, 4, 5, 6)
-      assert.deepEqual(4, queue.size)
-      assert.deepEqual(false, queue.isEmpty)
-      assert.deepEqual(data, queue.peek())
+      assert.deepStrictEqual(queue.size, 4)
+      assert.deepStrictEqual(queue.isEmpty, false)
+      assert.deepStrictEqual(queue.peek(), data)
     })
+
     it('should throw an error if offered null', function () {
       const queue = new Queue()
-      let errorThrown = false
-      try {
-        queue.offer(1, 2, 3, null, 4, 5, 6)
-      } catch (err) {
-        errorThrown = true
-      }
-      assert.deepEqual(true, errorThrown)
+      const errorThrown = testing.shouldThrow(() => queue.offer(1, 2, 3, null, 4, 5, 6))
+      assert.deepStrictEqual(errorThrown, true)
     })
+
+    it('should throw an error if offered undefined', function () {
+      const queue = new Queue()
+      const errorThrown = testing.shouldThrow(() => queue.offer(1, 2, 3, undefined, 4, 5, 6))
+      assert.deepStrictEqual(errorThrown, true)
+    })
+
     it('should add items in the correct order', function () {
       const queue = new Queue()
-      const data = array(10)
+      const data = testing.zeroTo(10)
       queue.offer(...data)
-      assert.deepEqual(10, queue.size)
-      assert.deepEqual(false, queue.isEmpty)
+      assert.deepStrictEqual(queue.size, 10)
+      assert.deepStrictEqual(queue.isEmpty, false)
 
       const polled = data.map(item => queue.poll())
 
-      assert.deepEqual(data, polled)
+      assert.deepStrictEqual(polled, data)
     })
   })
+
   describe('.offer(value)', function () {
     it('should update size and isEmpty', function () {
       const queue = new Queue()
       for (let i = 1; i < 10; i++) {
         queue.offer(i)
-        assert.deepEqual(i, queue.size)
-        assert.deepEqual(false, queue.isEmpty)
+        assert.deepStrictEqual(queue.size, i)
+        assert.deepStrictEqual(queue.isEmpty, false)
       }
     })
+
     it('should not break down arrays', function () {
       const queue = new Queue()
       const data = [1, 2, 3, 4, 5]
       queue.offer(data)
-      assert.deepEqual(1, queue.size)
-      assert.deepEqual(false, queue.isEmpty)
-      assert.deepEqual(data, queue.peek())
+      assert.deepStrictEqual(queue.size, 1)
+      assert.deepStrictEqual(queue.isEmpty, false)
+      assert.deepStrictEqual(queue.peek(), data)
     })
+
     it('should throw an error if offered null', function () {
       const queue = new Queue()
-      let errorThrown = false
-      try {
-        queue.offer(null)
-      } catch (err) {
-        errorThrown = true
-      }
-      assert.deepEqual(true, errorThrown)
+      const errorThrown = testing.shouldThrow(() => queue.offer(null))
+      assert.deepStrictEqual(errorThrown, true)
+    })
+
+    it('should throw an error if offered undefined', function () {
+      const queue = new Queue()
+      const errorThrown = testing.shouldThrow(() => queue.offer(undefined))
+      assert.deepStrictEqual(errorThrown, true)
     })
   })
+
   describe('.poll()', function () {
-    it('should return null if called on an empty queue', function () {
+    it('should return undefined if called on an empty queue', function () {
       const queue = new Queue()
-      assert.deepEqual(null, queue.poll())
+      assert.deepStrictEqual(queue.poll(), undefined)
     })
+
     it('should return the right element and remove it', function () {
       const queue = new Queue()
       queue.offer(1)
       queue.offer(2)
       queue.offer(3)
-      assert.deepEqual(3, queue.size)
-      assert.deepEqual(false, queue.isEmpty)
-      assert.deepEqual(1, queue.poll())
-      assert.deepEqual(2, queue.size)
-      assert.deepEqual(false, queue.isEmpty)
+      assert.deepStrictEqual(queue.size, 3)
+      assert.deepStrictEqual(queue.isEmpty, false)
+      assert.deepStrictEqual(queue.poll(), 1)
+      assert.deepStrictEqual(queue.size, 2)
+      assert.deepStrictEqual(queue.isEmpty, false)
     })
+
     it('should empty the queue when called enough times', function () {
       const queue = new Queue()
       for (let i = 0; i < 10; i++) {
         queue.offer(i)
       }
       for (let i = 0; i < 10; i++) {
-        assert.deepEqual(i, queue.poll())
+        assert.deepStrictEqual(queue.poll(), i)
       }
-      assert.deepEqual(null, queue.poll())
-      assert.deepEqual(0, queue.size)
-      assert.deepEqual(true, queue.isEmpty)
+      assert.deepStrictEqual(queue.poll(), undefined)
+      assert.deepStrictEqual(queue.size, 0)
+      assert.deepStrictEqual(queue.isEmpty, true)
     })
   })
+
   describe('.peek()', function () {
-    it('should return null if called on an empty queue', function () {
+    it('should return undefined if called on an empty queue', function () {
       const queue = new Queue()
-      assert.deepEqual(null, queue.peek())
+      assert.deepStrictEqual(queue.peek(), undefined)
     })
+
     it('should return the right element, but not remove it', function () {
       const queue = new Queue()
       queue.offer(1)
       queue.offer(2)
       queue.offer(3)
-      assert.deepEqual(3, queue.size)
-      assert.deepEqual(false, queue.isEmpty)
-      assert.deepEqual(1, queue.peek())
-      assert.deepEqual(3, queue.size)
-      assert.deepEqual(false, queue.isEmpty)
+      assert.deepStrictEqual(queue.size, 3)
+      assert.deepStrictEqual(queue.isEmpty, false)
+      assert.deepStrictEqual(queue.peek(), 1)
+      assert.deepStrictEqual(queue.size, 3)
+      assert.deepStrictEqual(queue.isEmpty, false)
     })
   })
+
   describe('.clear()', function () {
     it('should clear the queue', function () {
       const queue = new Queue()
       for (let i = 0; i < 10; i++) {
         queue.offer(i)
       }
-      assert.deepEqual(10, queue.size)
-      assert.deepEqual(false, queue.isEmpty)
+      assert.deepStrictEqual(queue.size, 10)
+      assert.deepStrictEqual(queue.isEmpty, false)
       queue.clear()
-      assert.deepEqual(0, queue.size)
-      assert.deepEqual(true, queue.isEmpty)
+      assert.deepStrictEqual(queue.size, 0)
+      assert.deepStrictEqual(queue.isEmpty, true)
+      assert.deepStrictEqual(queue.peek(), undefined)
     })
   })
 })
-
-function array(bound) {
-  return [...Array(bound).keys()]
-}

--- a/test/test-utility.js
+++ b/test/test-utility.js
@@ -1,0 +1,36 @@
+'use strict'
+
+function shouldThrow(func) {
+  try {
+    func()
+    return false
+  } catch (err) {
+    return true
+  }
+}
+
+async function shouldThrowAsync(func) {
+  try {
+    await func()
+    return false
+  } catch (err) {
+    return true
+  }
+}
+
+const shouldNotThrow = func => !shouldThrow(func)
+
+const shouldNotThrowAsync = func => !shouldThrowAsync(func)
+
+const wait = delay => new Promise((resolve, reject) => setTimeout(resolve, delay))
+
+const zeroTo = bound => [...Array(bound).keys()]
+
+module.exports = {
+  shouldThrow,
+  shouldThrowAsync,
+  shouldNotThrow,
+  shouldNotThrowAsync,
+  zeroTo,
+  wait
+}

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -13,6 +13,7 @@ describe('Utility', function () {
       assert.ok(isFunction(String))
       assert.ok(isFunction(Object))
     })
+
     it('should correctly return false', function () {
       assert.ok(!isFunction(undefined))
       assert.ok(!isFunction(null))
@@ -31,6 +32,7 @@ describe('Utility', function () {
       assert.ok(!isFunction({ prop: 'Hello World!' }))
     })
   })
+
   describe('.isInteger(value)', function () {
     const isInteger = utility.isInteger
     it('should correctly detect integers', function () {
@@ -40,6 +42,7 @@ describe('Utility', function () {
       assert.ok(isInteger(Number.MAX_SAFE_INTEGER))
       assert.ok(isInteger(Number.MIN_SAFE_INTEGER))
     })
+
     it('should correctly return false', function () {
       assert.ok(!isInteger(0.9999999999999))
       assert.ok(!isInteger(0.0000000000001))
@@ -56,6 +59,7 @@ describe('Utility', function () {
       assert.ok(!isInteger(() => { 1 + 1 }))
     })
   })
+
   describe('.isStrictPositiveInteger(value)', function () {
     const isStrictPositiveInteger = utility.isStrictPositiveInteger
     it('should correctly detect strictly positive integers (> 0)', function () {
@@ -65,6 +69,7 @@ describe('Utility', function () {
       assert.ok(isStrictPositiveInteger(Number.MAX_SAFE_INTEGER))
 
     })
+
     it('should correctly return false', function () {
       for (let i = -100; i <= 0; i++) {
         assert.ok(!isStrictPositiveInteger(i))


### PR DESCRIPTION
Closes #14. Touches on #15, but I do not consider this enough to close the issue. The tests have moved away from the deprecated deepEqual to deepStrictEqual and the arguments have been moved around to match the parameters "actual" and "expected". Also fixed a bug in a test that passed without actually testing. Fortunately, the test passes after the fix.

Signed-off-by: Emil Englesson englesson.emil@gmail.com