### PR TITLE
Better benchmarks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,15 @@
 {
   "name": "@limeeng/semaphore",
-  "version": "0.5.7",
+  "version": "0.5.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -34,6 +40,23 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "cli-table3": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "object-assign": "^4.1.0",
+        "string-width": "^2.1.1"
+      }
+    },
+    "colors": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
+      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
       "dev": true
     },
     "commander": {
@@ -123,6 +146,12 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -178,6 +207,12 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -198,6 +233,25 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
       "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
       "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
     },
     "supports-color": {
       "version": "5.4.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "license": "MIT",
   "devDependencies": {
     "benchmark": "^2.1.4",
+    "cli-table3": "^0.5.1",
+    "colors": "^1.3.2",
     "mocha": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limeeng/semaphore",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "Semaphores, with promises. Limit access to resources in a safe and easy manner",
   "main": "index.js",
   "repository": {

--- a/test/performance/perf.js
+++ b/test/performance/perf.js
@@ -1,94 +1,97 @@
 'use strict'
 
-const Benchmark = require('benchmark');
+const Benchmark = require('benchmark')
 const Semaphore = require('../../index.js')
+const printPlatform = require('./print-platform.js')
+const printBenchmarks = require('./print-benchmarks.js')
 
-const suite = new Benchmark.Suite
+runAllBenchmarks()
 
-const platform = Benchmark.platform
-console.log('Executing tests on:')
-console.log('==============')
-console.log('Name:         ' + platform.name)
-console.log('Version:      ' + platform.version)
-console.log('Product:      ' + platform.product)
-console.log('Manufacturer: ' + platform.manufacturer)
-console.log('Layout:       ' + platform.layout)
-console.log('OS:           ' + platform.os)
-console.log('Description:  ' + platform.description)
-console.log('==============')
-
-for (let semLimit = 10; semLimit <= 10; semLimit++) {
-  for (let amount = 10; amount <= 1000000; amount = amount * 10) {
-    suite.add(generateTestCase(semLimit, amount))
+async function runAllBenchmarks() {
+  printPlatform()
+  const bounds = [10, 100, 1000, 10000, 100000, 1000000, 5000000, 10000000]
+  const benchmarks = []
+  for (const bound of bounds) {
+    const result = await runBasicLockTest(bound)
+    benchmarks.push(result)
   }
+  printBenchmarks(benchmarks)
 }
 
-let totalTests = suite.length
-let finished = 0
-suite
-  .on('cycle', function (event) {
-    finished += 1
-    console.log(finished + '/' + totalTests + ' completed: ' + event.target);
+async function runBasicLockTest(nbrOfPromises) {
+  const info = 'Execute ' + nbrOfPromises + ' promises'
+  return runSuite(info, () => {
+    const promises = array(nbrOfPromises).map(() => promiseFunc())
+    return createBasicPerfSuite(sem => {
+      return deferred => {
+        const allPromises = promises.map(promise => sem.lock(promise))
+        Promise.all(allPromises)
+          .then(() => deferred.resolve())
+      }
+    })
   })
-  .on('complete', function () {
-    console.log('============>')
-    for (var i = 0; i < this.length; i++) {
-      const benchmark = this[i]
-      console.log(benchmark.toString());
-      console.log('    ' + benchmark.times.period.toFixed(2) + ' s per test')
+}
+
+function runSuite(info, suiteFactory) {
+  return new Promise((resolve, reject) => {
+    console.log()
+    console.log(info)
+    console.log('-'.repeat(info.length))
+    const obj = {
+      title: info,
+      results: []
+    }
+    suiteFactory()
+      .on('cycle', function (e) {
+        console.log(String(e.target))
+      })
+      .on('complete', function () {
+        for (let i = 0; i < this.length; i++) {
+          obj.results.push(this[i])
+        }
+        resolve(obj)
+      })
+      .on('error', function () {
+        reject()
+      })
+      .run({ async: true })
+  })
+}
+
+function createBasicPerfSuite(createTestFunc) {
+  let suite = new Benchmark.Suite()
+  const semaphores = getSemaphores()
+
+  semaphores.forEach(obj => {
+    suite = suite.add(obj.name, createTestFunc(obj.semaphore), { defer: true })
+  })
+  return suite
+}
+
+function getSemaphores() {
+  const queues = []
+
+  queues.push({ name: 'Semaphore(1)', semaphore: new Semaphore(1) })
+  queues.push({ name: 'Semaphore(2)', semaphore: new Semaphore(2) })
+  queues.push({ name: 'Semaphore(10)', semaphore: new Semaphore(10) })
+  queues.push({ name: 'Semaphore(100)', semaphore: new Semaphore(100) })
+  queues.push({ name: 'Semaphore(1000)', semaphore: new Semaphore(1000) })
+  queues.push({ name: 'Semaphore(10000)', semaphore: new Semaphore(10000) })
+  queues.push({
+    name: 'baseline', semaphore: {
+      lock: function (thunk) {
+        return thunk()
+      }
     }
   })
-  .run({ 'async': true });
 
-function generateTestCase(semLimit, taskCount) {
-  function array(bound) {
-    return [...Array(bound).keys()]
-  }
-  function setup() {
-    // Why globals? See end of file
-    global.sem = new Semaphore(semLimit)
-    global.promises = array(taskCount).map(() => () => new Promise((resolve, reject) => process.nextTick(resolve)))
-  }
-  function fn(deferred) {
-    const allPromises = promises.map((promise) => sem.lock(promise))
-    Promise.all(allPromises)
-      .then(() => deferred.resolve())
-  }
-  return {
-    setup: setup,
-    fn: fn,
-    defer: true,
-    name: 'Semaphore(' + semLimit + ') -> ' + taskCount + ' promises'
-  }
+  return queues
 }
 
-// SOURCE: https://github.com/bestiejs/benchmark.js/issues/51
+function array(bound) {
+  return [...Array(bound).keys()]
+}
 
-// This is because when you pass a function to benchmark.js it will attempt to decompile it and reconstruct it in a test loop.
-//
-// .add('create graph', function() {
-//     schedule.dependencyGraph(tasks);
-// },
-// {
-//     'setup': function() {
-//         var tasks = ['A', 'B', 'C', 'D', 'E'];
-//     }
-// })
-// becomes:
-//
-// var tasks = ['A', 'B', 'C', 'D', 'E'];
-//
-// while (....) {
-//   schedule.dependencyGraph(tasks);
-// }
-// This would be great, however functions compiled in Node don't have access to variables your modules scope. So it can't access schedule and so throws and error and attempts to fallback to the non-compiled approach which then turns your code into:
-//
-// this.setup();
-// while (....) {
-//   schedule.dependencyGraph(tasks);
-// }
-// and now the test doesn't have access to tasks and throws an error.
-//
-// To avoid this define schedule on the global object like:
-//
-// global.schedule = require('../index');
+function promiseFunc() {
+  return () => new Promise((resolve, reject) => process.nextTick(resolve))
+}

--- a/test/performance/perf.js
+++ b/test/performance/perf.js
@@ -9,7 +9,7 @@ runAllBenchmarks()
 
 async function runAllBenchmarks() {
   printPlatform()
-  const bounds = [10, 100, 1000, 10000, 100000, 1000000, 5000000, 10000000]
+  const bounds = [10, 100, 1000, 10000]
   const benchmarks = []
   for (const bound of bounds) {
     const result = await runBasicLockTest(bound)

--- a/test/performance/print-benchmarks.js
+++ b/test/performance/print-benchmarks.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const Table = require('cli-table3')
+const colorize = require('colors/safe')
+
+function printBenchmarks(benchmarks) {
+  const longestTitle = Math.max(...(benchmarks
+    .map(item => item.title)
+    .map(title => title.length)))
+  benchmarks.forEach(benchmark => printAsTable(benchmark, longestTitle))
+}
+
+function printAsTable(benchmark, longestTitle) {
+
+  var table = new Table({ style: { head: [], border: [] } })
+
+  const fastestHz = Math.max(...(benchmark.results
+    .map(item => item.hz)))
+
+  const arrays = benchmark.results.map(item => {
+    let percentage = 'fastest'
+    if (item.hz !== fastestHz) {
+      percentage = '-' + ((1 - item.hz / fastestHz) * 100).toFixed(2) + '%'
+    }
+    return [
+      item.name,
+      formatNumber(item.hz.toFixed(item.hz < 100 ? 2 : 0)) + ' \xb1 ' + item.stats.rme.toFixed(2) + '%',
+      item.stats.sample.length,
+      percentage
+    ]
+  })
+
+  table.push(
+    [{ hAlign: 'center', colSpan: 4, content: colorize.green(padTitle(benchmark.title, longestTitle)) }],
+    ['name', 'ops/sec', 'runs sampled', 'performance'].map(item => colorize.green(item))
+  )
+  arrays.forEach(row => table.push(row))
+  console.log(table.toString())
+}
+
+function formatNumber(number) {
+  return Intl.NumberFormat('en-US').format(number)
+}
+
+function padTitle(title, targetLength) {
+  let end = true
+  while (title.length < targetLength) {
+    title = end ? title + ' ' : ' ' + title
+    end = !end
+  }
+  return title
+}
+
+module.exports = printBenchmarks

--- a/test/performance/print-platform.js
+++ b/test/performance/print-platform.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const os = require('os')
+
+function printPlatform() {
+  const platform = `${os.type()} ${os.release()} ${os.arch()}`
+  const node = `Node.js ${process.versions.node}`
+  const v8 = `V8 ${process.versions.v8}`
+  const cpus = getCpuInfo()
+
+  console.log('Platform info:')
+  console.log()
+  console.log(platform)
+  console.log(node)
+  console.log(v8)
+  console.log(cpus)
+}
+
+function getCpuInfo() {
+  const cpus = os.cpus()
+    .map(cpu => cpu.model)
+    .reduce((acc, model) => {
+      acc[model] = (acc[model] || 0) + 1
+      return acc
+    }, {})
+
+  return Object.keys(cpus)
+    .map(cpu => cpu + ' x ' + cpus[cpu])
+    .join('\n')
+}
+
+module.exports = printPlatform


### PR DESCRIPTION
The benchmarks are now neatly printed in tables, with color. The benchmarks are also better designed since they compare against a baseline. Performance is right now very poor.

```
┌────────────────────────────────────────────────────────────────┐
│                      Execute 100 promises                      │
├──────────────────┬────────────────┬──────────────┬─────────────┤
│ name             │ ops/sec        │ runs sampled │ performance │
├──────────────────┼────────────────┼──────────────┼─────────────┤
│ Semaphore(1)     │ 9,430 ± 1.49%  │ 83           │ -87.39%     │
├──────────────────┼────────────────┼──────────────┼─────────────┤
│ Semaphore(2)     │ 10,123 ± 1.44% │ 87           │ -86.46%     │
├──────────────────┼────────────────┼──────────────┼─────────────┤
│ Semaphore(10)    │ 10,342 ± 1.33% │ 87           │ -86.17%     │
├──────────────────┼────────────────┼──────────────┼─────────────┤
│ Semaphore(100)   │ 10,544 ± 0.47% │ 87           │ -85.90%     │
├──────────────────┼────────────────┼──────────────┼─────────────┤
│ Semaphore(1000)  │ 10,639 ± 0.38% │ 91           │ -85.77%     │
├──────────────────┼────────────────┼──────────────┼─────────────┤
│ Semaphore(10000) │ 10,532 ± 0.83% │ 88           │ -85.91%     │
├──────────────────┼────────────────┼──────────────┼─────────────┤
│ baseline         │ 74,766 ± 1.30% │ 85           │ fastest     │
└──────────────────┴────────────────┴──────────────┴─────────────┘
```

Hopefully #3 can fix most of these problems.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>