### PR TITLE
onIdle utility function

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,13 @@ const Semaphore = require('@limeeng/semaphore')
 
 const sem = new Semaphore(2)
 
-sem.lock(task1)
-sem.lock(task2)
-sem.lock(task3)
+sem.lock(() => console.log('#1'))
+sem.lock(() => console.log('#2'))
 
-sem.onIdle().then(() => console.log('Done!'))
+sem.onIdle().then(() => console.log('Done! #5'))
+
+sem.lock(() => console.log('#3'))
+sem.lock(() => console.log('#4'))
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ function sharedResource() {
 }
 ```
 
+### semaphore.onIdle()
+
+Returns a promise that resolves when all tasks submitted to the semaphore has completed. Can be called multiple times and it is possible to add more tasks after a call to this function.
+
+```js
+const Semaphore = require('@limeeng/semaphore')
+
+const sem = new Semaphore(2)
+
+sem.lock(task1)
+sem.lock(task2)
+sem.lock(task3)
+
+sem.onIdle().then(() => console.log('Done!'))
+```
+
 ## Examples
 
 This will create a version of `got` with concurrency set to 16. That is, no more than 16 requests will be in flight at any given time.

--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -31,7 +31,7 @@ class Semaphore {
   }
 
   async onEmpty() {
-    if (this.count === this.originalCount && this.tasks.size === 0) {
+    if (this.count === this.originalCount && this.tasks.isEmpty) {
       return Promise.resolve()
     }
     return new Promise((resolve, reject) => {
@@ -39,7 +39,7 @@ class Semaphore {
 			this.resolveIdle = () => {
 				previousResolve()
 				resolve()
-			};
+			}
     })
   }
 }

--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -10,6 +10,8 @@ class Semaphore {
       throw new Error('Count must be an integer > 0, got ' + count)
     }
     this.count = count
+    this.originalCount = count
+    this.resolveIdle = () => {}
     this.tasks = new Queue()
   }
 
@@ -29,8 +31,22 @@ class Semaphore {
   }
 
   async onEmpty() {
-    return Promise.resolve()
+    if (this.count === this.originalCount && this.tasks.size === 0) {
+      return Promise.resolve()
+    }
+    return new Promise((resolve, reject) => {
+      const previousResolve = this.resolveIdle
+			this.resolveIdle = () => {
+				previousResolve()
+				resolve()
+			};
+    })
   }
+}
+
+function signalEmpty(semaphore) {
+  semaphore.resolveIdle()
+  semaphore.resolveIdle = () => {}
 }
 
 function acquire(semaphore) {
@@ -52,6 +68,9 @@ function runNext(semaphore) {
     semaphore.count--
     const next = semaphore.tasks.poll()
     next()
+  }
+  if (semaphore.count === semaphore.originalCount && semaphore.tasks.isEmpty) {
+    signalEmpty(semaphore)
   }
 }
 

--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -30,7 +30,7 @@ class Semaphore {
     }
   }
 
-  async onEmpty() {
+  async onIdle() {
     if (this.count === this.originalCount && this.tasks.isEmpty) {
       return Promise.resolve()
     }

--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -27,6 +27,10 @@ class Semaphore {
       throw err
     }
   }
+
+  async onEmpty() {
+    return Promise.resolve()
+  }
 }
 
 function acquire(semaphore) {

--- a/lib/semaphore.js
+++ b/lib/semaphore.js
@@ -9,10 +9,10 @@ class Semaphore {
     if (!utility.isStrictPositiveInteger(count)) {
       throw new Error('Count must be an integer > 0, got ' + count)
     }
-    this.count = count
-    this.originalCount = count
-    this.resolveIdle = () => {}
-    this.tasks = new Queue()
+    this._count = count
+    this._ceiling = count
+    this._resolveIdle = () => {}
+    this._tasks = new Queue()
   }
 
   async lock(thunk) {
@@ -31,12 +31,12 @@ class Semaphore {
   }
 
   async onIdle() {
-    if (this.count === this.originalCount && this.tasks.isEmpty) {
+    if (this._count === this._ceiling && this._tasks.isEmpty) {
       return Promise.resolve()
     }
     return new Promise((resolve, reject) => {
-      const previousResolve = this.resolveIdle
-			this.resolveIdle = () => {
+      const previousResolve = this._resolveIdle
+			this._resolveIdle = () => {
 				previousResolve()
 				resolve()
 			}
@@ -44,33 +44,33 @@ class Semaphore {
   }
 }
 
-function signalEmpty(semaphore) {
-  semaphore.resolveIdle()
-  semaphore.resolveIdle = () => {}
+function signalIdle(semaphore) {
+  semaphore._resolveIdle()
+  semaphore._resolveIdle = () => {}
 }
 
 function acquire(semaphore) {
   return new Promise((resolve, reject) => {
     const task = () => {
       const release = () => {
-        semaphore.count++
+        semaphore._count += 1
         runNext(semaphore)
       }
       resolve(release)
     }
-    semaphore.tasks.offer(task)
+    semaphore._tasks.offer(task)
     process.nextTick(() => runNext(semaphore))
   })
 }
 
 function runNext(semaphore) {
-  if (semaphore.count > 0 && !semaphore.tasks.isEmpty) {
-    semaphore.count--
-    const next = semaphore.tasks.poll()
+  if (semaphore._count > 0 && !semaphore._tasks.isEmpty) {
+    semaphore._count -= 1
+    const next = semaphore._tasks.poll()
     next()
   }
-  if (semaphore.count === semaphore.originalCount && semaphore.tasks.isEmpty) {
-    signalEmpty(semaphore)
+  if (semaphore._count === semaphore._ceiling && semaphore._tasks.isEmpty) {
+    signalIdle(semaphore)
   }
 }
 

--- a/test/semaphore.test.js
+++ b/test/semaphore.test.js
@@ -136,8 +136,6 @@ describe('Semaphore', function () {
       }
 
       const runningTasks = testing.zeroTo(5).map(() => sem.lock(() => task()))
-      // TODO: Why does the addition of then() actually work?
-      // Something with the next loop of the event loop? Figure out before merge.
       const onIdlePromise = sem.onIdle().then()
 
       const result = await Promise.race([Promise.all(runningTasks), onIdlePromise])
@@ -176,8 +174,6 @@ describe('Semaphore', function () {
       }
 
       const runningTasks1 = testing.zeroTo(5).map(() => sem.lock(() => task()))
-      // TODO: Why does the addition of then() actually work?
-      // Something with the next loop of the event loop? Figure out before merge.
       const onIdlePromise = sem.onIdle().then()
       const runningTasks2 = testing.zeroTo(5).map(() => sem.lock(() => task()))
 
@@ -202,8 +198,6 @@ describe('Semaphore', function () {
       }
 
       const runningTasks1 = testing.zeroTo(5).map(() => sem.lock(() => task()))
-      // TODO: Why does the addition of then() actually work?
-      // Something with the next loop of the event loop? Figure out before merge.
       const onIdlePromise = sem.onIdle().then()
       const runningTasks2 = testing.zeroTo(5).map(() => sem.lock(() => task()))
 

--- a/test/semaphore.test.js
+++ b/test/semaphore.test.js
@@ -125,4 +125,14 @@ describe('Semaphore', function () {
       assert.ok(shouldThrow({ prop: 'Hello there!' }))
     })
   })
+
+  describe('.onEmpty()', function () {
+    it.skip('should resolve when queue is empty', async function () {
+      const sem = new Semaphore(2)
+    })
+
+    it.skip('should not reject if all promises in the queue reject', async function () {
+      const sem = new Semaphore(2)
+    })
+  })
 })

--- a/test/semaphore.test.js
+++ b/test/semaphore.test.js
@@ -139,7 +139,12 @@ describe('Semaphore', function () {
       const onEmptyPromise = sem.onEmpty()
 
       const result = await Promise.race([Promise.all(runningTasks), onEmptyPromise])
-      assert.deepStrictEqual(result, 'From task')
+      if (Array.isArray(result)) {
+        const passed = result.every(item => item === 'From task')
+        assert(passed)
+      } else {
+        assert.fail()
+      }
 
       return onEmptyPromise
     })
@@ -154,7 +159,6 @@ describe('Semaphore', function () {
 
       async function waitThenReject(promises) {
         await Promise.all(promises.map(promise => promise.catch(e => e)))
-        console.log('Hello there!')
         return Promise.reject('All tasks rejected!')
       }
 
@@ -188,7 +192,12 @@ describe('Semaphore', function () {
       const runningTasks2 = testing.zeroTo(20).map(() => sem.lock(() => task()))
 
       const result = await Promise.race([Promise.all(runningTasks1.concat(runningTasks2)), onEmptyPromise])
-      assert.deepStrictEqual(result, 'From task')
+      if (Array.isArray(result)) {
+        const passed = result.every(item => item === 'From task')
+        assert(passed)
+      } else {
+        assert.fail()
+      }
 
       return onEmptyPromise
     })
@@ -206,9 +215,19 @@ describe('Semaphore', function () {
       const runningTasks2 = testing.zeroTo(20).map(() => sem.lock(() => task()))
 
       const result = await Promise.race([Promise.all(runningTasks1.concat(runningTasks2)), onEmptyPromise])
-      assert.deepStrictEqual(result, 'From task')
+      if (Array.isArray(result)) {
+        const passed = result.every(item => item === 'From task')
+        assert(passed)
+      } else {
+        assert.fail()
+      }
 
       return onEmptyPromise
+    })
+
+    it('should resolve immediately if no other tasks have been added', async function () {
+      const sem = new Semaphore(2)
+      return sem.onEmpty()
     })
   })
 })

--- a/test/semaphore.test.js
+++ b/test/semaphore.test.js
@@ -126,7 +126,7 @@ describe('Semaphore', function () {
     })
   })
 
-  describe('.onEmpty()', function () {
+  describe('.onIdle()', function () {
     it('should resolve when queue is empty', async function () {
       const sem = new Semaphore(2)
 
@@ -138,9 +138,9 @@ describe('Semaphore', function () {
       const runningTasks = testing.zeroTo(5).map(() => sem.lock(() => task()))
       // TODO: Why does the addition of then() actually work?
       // Something with the next loop of the event loop? Figure out before merge.
-      const onEmptyPromise = sem.onEmpty().then()
+      const onIdlePromise = sem.onIdle().then()
 
-      const result = await Promise.race([Promise.all(runningTasks), onEmptyPromise])
+      const result = await Promise.race([Promise.all(runningTasks), onIdlePromise])
       if (Array.isArray(result)) {
         assert(result.length === 5)
         const passed = result.every(item => item === 'From task')
@@ -149,7 +149,7 @@ describe('Semaphore', function () {
         assert.fail()
       }
 
-      return onEmptyPromise
+      return onIdlePromise
     })
 
     it('should not reject even if all promises in the queue reject', async function () {
@@ -162,11 +162,11 @@ describe('Semaphore', function () {
 
       const runningTasks = testing.zeroTo(5).map(() => sem.lock(() => task()).catch(e => e))
 
-      return Promise.all([runningTasks, sem.onEmpty()])
+      return Promise.all([runningTasks, sem.onIdle()])
     })
 
     it('should not limit concurrent execution', async function () {
-      // If the onEmpty promise would limit execution, a semaphore with a count 
+      // If the onIdle promise would limit execution, a semaphore with a count 
       // of one would not allow other promises to execute at the same time
       const sem = new Semaphore(1)
 
@@ -178,10 +178,10 @@ describe('Semaphore', function () {
       const runningTasks1 = testing.zeroTo(5).map(() => sem.lock(() => task()))
       // TODO: Why does the addition of then() actually work?
       // Something with the next loop of the event loop? Figure out before merge.
-      const onEmptyPromise = sem.onEmpty().then()
+      const onIdlePromise = sem.onIdle().then()
       const runningTasks2 = testing.zeroTo(5).map(() => sem.lock(() => task()))
 
-      const result = await Promise.race([Promise.all(runningTasks1.concat(runningTasks2)), onEmptyPromise])
+      const result = await Promise.race([Promise.all(runningTasks1.concat(runningTasks2)), onIdlePromise])
       if (Array.isArray(result)) {
         assert(result.length === 10)
         const passed = result.every(item => item === 'From task')
@@ -190,7 +190,7 @@ describe('Semaphore', function () {
         assert.fail()
       }
 
-      return onEmptyPromise
+      return onIdlePromise
     })
 
     it('should not prevent more promises to be added while active', async function () {
@@ -204,10 +204,10 @@ describe('Semaphore', function () {
       const runningTasks1 = testing.zeroTo(5).map(() => sem.lock(() => task()))
       // TODO: Why does the addition of then() actually work?
       // Something with the next loop of the event loop? Figure out before merge.
-      const onEmptyPromise = sem.onEmpty().then()
+      const onIdlePromise = sem.onIdle().then()
       const runningTasks2 = testing.zeroTo(5).map(() => sem.lock(() => task()))
 
-      const result = await Promise.race([Promise.all(runningTasks1.concat(runningTasks2)), onEmptyPromise])
+      const result = await Promise.race([Promise.all(runningTasks1.concat(runningTasks2)), onIdlePromise])
       if (Array.isArray(result)) {
         assert(result.length === 10)
         const passed = result.every(item => item === 'From task')
@@ -216,12 +216,12 @@ describe('Semaphore', function () {
         assert.fail()
       }
 
-      return onEmptyPromise
+      return onIdlePromise
     })
 
     it('should resolve immediately if no other tasks have been added', async function () {
       const sem = new Semaphore(2)
-      return sem.onEmpty()
+      return sem.onIdle()
     })
   })
 })

--- a/test/semaphore.test.js
+++ b/test/semaphore.test.js
@@ -172,5 +172,13 @@ describe('Semaphore', function () {
 
       return Promise.all([raced, onEmptyPromise])
     })
+
+    it('should not limit concurrent execution', async function () {
+      const sem = new Semaphore(2)
+    })
+
+    it('should not prevent more promises to be added while active', async function () {
+      const sem = new Semaphore(2)
+    })
   })
 })

--- a/test/semaphore.test.js
+++ b/test/semaphore.test.js
@@ -127,8 +127,22 @@ describe('Semaphore', function () {
   })
 
   describe('.onEmpty()', function () {
-    it.skip('should resolve when queue is empty', async function () {
+    it('should resolve when queue is empty', async function () {
       const sem = new Semaphore(2)
+
+      function task() {
+        return testing.wait(10)
+          .then(() => 'From task')
+      }
+
+      const runningTasks = testing.zeroTo(20).map(() => sem.lock(() => task()))
+      const onEmptyPromise = sem.onEmpty()
+
+      const result = await Promise.race([Promise.all(runningTasks), onEmptyPromise])
+      console.log(result)
+      assert.deepStrictEqual(result, 'From task')
+
+      await onEmptyPromise
     })
 
     it.skip('should not reject if all promises in the queue reject', async function () {


### PR DESCRIPTION
Fixes #22 

The function has been renamed `onIdle` since it better reflects what it does. Bundled with this feature are renamed internal properties. They have been prefixed with a underscore to discourage widespread usage. But since these properties never were a part of the public API this will be considered a minor bump overall.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>