### PR TITLE
Release v0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limeeng/semaphore",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Semaphores, with promises. Limit access to resources in a safe and easy manner",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This will mark the release of `v0.7`.

Names of internal attributes used by the semaphore has been prefixed with a underscore to discourage widespread usage. But since these properties never were a part of the public API this will be considered a minor bump overall. The semaphore has gained a function `onIdle`.

Signed-off-by: Emil Englesson englesson.emil@gmail.com